### PR TITLE
Add conda environment (in parallel with pip requirements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Setup (python 3.8):
 pip install -r requirements.txt
 ```
 
+Alternatively with conda `environment.yml`:
+```
+conda env create -f environment.yml
+conda activate summary-analysis
+```
+
 ### Run dashboard app
 ```
 streamlit run dashboard.py

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: summary-analysis
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pip
+  - python=3.8
+  - pip:
+    - streamlit==1.5.0
+    - watchdog==2.1.6
+    - datasets==1.18.2


### PR DESCRIPTION
Just creating an environment named `summary-analysis` with the exact same packages as what's already in `requirements.txt`, bundled up with explicitly requiring Python 3.8. I'm not actually sure which environment management system most people use though.

(the scaffold branch should probably be closed after this)