### PR TITLE
Script for evaluating summaries with NLI model

### DIFF
--- a/sumtool/plot_summary_nli_results.py
+++ b/sumtool/plot_summary_nli_results.py
@@ -27,12 +27,14 @@ def get_xsum_datapoints(n: int = 1000, shuffle: bool = False) -> Dict[str, List[
 
     Args:
         n (int): number of datapoints to return
+        shuffle: (bool) whether to shuffle dataset
 
-    Returns: {
-        'document': List[str] of original documents from xsum data
-        'summary': List[str] of ground-truth summaries from xsum data
-        'auto_summary': List[str] of machine-written summaries for documents
-    }
+    Returns:
+        {
+            'document': List[str] of original documents from xsum data
+            'summary': List[str] of ground-truth summaries from xsum data
+            'auto_summary': List[str] of machine-written summaries for documents
+        }
     """
     summarizer = pipeline(
         "summarization", model="t5-base", tokenizer="t5-base", device=0
@@ -79,14 +81,16 @@ def get_entailment_label_from_model(
 
 def plot_nli_data(xsum_train: Dict[str, List[str]]):
     """Creates a plot showing the frequencies of each NLI label in human-written and machine-written summaries.
+
     Args:
-        xsum_train: {
-            'document': List[str] of original documents from xsum data
-            'summary': List[str] of ground-truth summaries from xsum data
-            'auto_summary': List[str] of machine-written summaries for documents
-            'nli_label': List[int] of labels for ground-truth summaries
-            'auto_nli_label': List[int] of labels for machine-written summaries
-        }
+        xsum_train: a Dict[str, List[str]] with the following structure
+            {
+                'document': List[str] of original documents from xsum data
+                'summary': List[str] of ground-truth summaries from xsum data
+                'auto_summary': List[str] of machine-written summaries for documents
+                'nli_label': List[int] of labels for ground-truth summaries
+                'auto_nli_label': List[int] of labels for machine-written summaries
+            }
     """
     #
     # Create dataframe with all this stuff


### PR DESCRIPTION
This is what my script does
- Gets summaries using huggingface t5-base summarizer (TODO: integrate with other people to support other summarization models)
- Loads samples from the xsum dataset (TODO: integrate with dataloader people)
- Gets summaries for specified number of datapoints
- Runs real and generated summaries through NLI model to count number of 'entailment', 'contradiction', and 'neutral' labels
- Plots the number of labels for each type of summary, human-written and machine-written (TODO: integrate with visualization people)

Here's the associated Colab notebook: https://colab.research.google.com/drive/1Ubo3Q_cIN3z5C3Tm0xvZ1QzGmB7IRiCY?usp=sharing

Strangely, our results so far are showing the human-written summaries generate more 'contradiction' labels than the machine-written ones. This is not what we'd expect!
<img width="825" alt="Screen Shot 2022-02-08 at 12 13 43 PM" src="https://user-images.githubusercontent.com/13238952/153039735-150a3204-b845-4e89-990d-f2062d543182.png">

One obvious issue is that MNLI (the dataset the entailment model was trained on) is generally composed of very short sentence-pairs of similar length, while the xsum data consists of one very long document and one very short summary. It's sketchy for us to expect that the NLI model should understand the xsum data at all.

A potential fix for this is to parse the document into sentences and generate an entailment label for each sentence paired with the overall summary. Then we'd get multiple NLI labels for each input, and could aggregate them into an overall prediction. This would probably be a more accurate way to check for contradictions.

Finally, this is pretty slow-- there's no batching at all, and we don't cache any of the results either. When we integrate this into the final tool we probably want to store NLI results so we don't have to recompute them every time we want to do any sort of analysis.

(Closes #8)