### PR TITLE
Add VScode configuration inline with CI enforcement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": ["--ignore=N801, E203, E266, E501, W503, F812, E741, N803, N802, N806"],
+    "python.linting.enabled": true,
+    "python.formatting.provider": "black"
+}


### PR DESCRIPTION
- lint with flake8, with provided exclusions
- format with black