### PR TITLE
Ngram lookup minor fix

### DIFF
--- a/interface/backend/viz_ngram_loader.py
+++ b/interface/backend/viz_ngram_loader.py
@@ -46,7 +46,8 @@ def build_ngram_lookup(
 
     # build ngram dictionary with multithreading
     p2 = threading.Thread(
-        target=ngram_lookup.build_ngram_dictionary, args=(ngram_path, min_n, max_n, save_flag)
+        target=ngram_lookup.build_ngram_dictionary,
+        args=(ngram_path, min_n, max_n, save_flag),
     )
     p2.start()
     p2.join()

--- a/interface/ngram_interface.py
+++ b/interface/ngram_interface.py
@@ -42,10 +42,18 @@ def render_ngram_interface():
     # build or load ngram
     if build_flag:
         ngram_lookup = build_ngram_lookup(
-            x_sum_dataset, VOCABS_PATH, NGRAM_PATH, MAX_VOCAB_SIZE, MIN_N, MAX_N, SAVE_FLAG
+            x_sum_dataset,
+            VOCABS_PATH,
+            NGRAM_PATH,
+            MAX_VOCAB_SIZE,
+            MIN_N,
+            MAX_N,
+            SAVE_FLAG,
         )
     else:
-        ngram_lookup = load_ngram_lookup(VOCABS_PATH, NGRAM_PATH, MAX_VOCAB_SIZE, MIN_N, MAX_N)
+        ngram_lookup = load_ngram_lookup(
+            VOCABS_PATH, NGRAM_PATH, MAX_VOCAB_SIZE, MIN_N, MAX_N
+        )
 
     st.header("XSUM N-Gram Lookup")
 

--- a/sumtool/ngram/ngram_lookup.py
+++ b/sumtool/ngram/ngram_lookup.py
@@ -273,7 +273,8 @@ def main():
 
     # build ngram dictionary with multithreading
     p2 = threading.Thread(
-        target=ngram_lookup.build_ngram_dictionary, args=(NGRAM_PATH, MIN_N, MAX_N, SAVE_FLAG)
+        target=ngram_lookup.build_ngram_dictionary,
+        args=(NGRAM_PATH, MIN_N, MAX_N, SAVE_FLAG),
     )
     p2.start()
     p2.join()


### PR DESCRIPTION
* I found a bug from interface/backend/viz_ngram_loader.py while building a new ngram dictionary -> removed unnecessary code snippet
* Fixed `NgramLookup` class to input minimum ngram size `min_n` as well as `max_n` for future use